### PR TITLE
FIX: deployment.yaml missing values tag in env

### DIFF
--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -75,7 +75,7 @@ spec:
           env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}
-              {{- toYaml $value | nindent 14 }}
+              value: {{- toYaml $value | nindent 14 }}
             {{- end }}
           lifecycle:
             {{- toYaml .Values.main.lifecycle | nindent 12 }}


### PR DESCRIPTION
This PR fixes charts/n8n/templates/deployment.yaml file.
If attempting to add extraEnv in values.yaml , one will get: `error converting YAML to JSON: yaml: line 46: could not find expected ':'`. This is due to new logic since 1.0.0 In order to fix that add "value" key with the actual value after ":" instead of just outputting the value i a single line